### PR TITLE
Fixed an issue where we would use the request time in all cases.

### DIFF
--- a/vigir_footstep_planner/src/footstep_planner.cpp
+++ b/vigir_footstep_planner/src/footstep_planner.cpp
@@ -417,7 +417,7 @@ msgs::ErrorStatus FootstepPlanner::planSteps(msgs::StepPlanRequestService::Reque
 
   reset();
 
-  ReplanParams params(req.plan_request.max_planning_time > 0 ? req.plan_request.max_planning_time : env_params->max_planning_time);
+  ReplanParams params(req.plan_request.max_planning_time > env_params->max_planning_time ? req.plan_request.max_planning_time : env_params->max_planning_time);
   params.initial_eps = env_params->initial_eps;
   params.final_eps = 1.0;
   params.dec_eps = env_params->decrease_eps;


### PR DESCRIPTION
it seems like the OCS is sending a footstep planning time, which
automatically overwrote the planning time parameter. This version
will behave more intuitively, where the max_planning_time is a lower
bound on the time allocated to the planner.

The OCS is sending a planning time of 5 seconds which doesn't reflect the selected parameter set, making this change will cause it to use the parameter set planning time.
